### PR TITLE
docs: fix repo link

### DIFF
--- a/ai_plugins/memory_plugin/README.md
+++ b/ai_plugins/memory_plugin/README.md
@@ -31,7 +31,7 @@ Package memory\_plugin provides wiring functions for memory\-backed agents. Use 
 
 
 <a name="MemoryAgent"></a>
-## func [MemoryAgent](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/wiring.go#L41>)
+## func [MemoryAgent](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/wiring.go#L41>)
 
 ```go
 func MemoryAgent(spec wiring.WiringSpec, name string, agentName string, memoryName string) string
@@ -42,7 +42,7 @@ MemoryAgent wraps an existing agent with LLM\-driven memory capabilities. The ag
 agentName must reference an already\-defined agent in the spec. memoryName must reference an already\-defined memory store in the spec.
 
 <a name="MemoryStore"></a>
-## func [MemoryStore](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/wiring.go#L23>)
+## func [MemoryStore](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/wiring.go#L23>)
 
 ```go
 func MemoryStore[Impl core.Memory](spec wiring.WiringSpec, name string) string
@@ -61,7 +61,7 @@ memStore := memory_plugin.MemoryStore[*redis.RedisMemory](spec, "my_memory")
 ```
 
 <a name="MemoryAgentClient"></a>
-## type [MemoryAgentClient](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L74-L83>)
+## type [MemoryAgentClient](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L74-L83>)
 
 MemoryAgentClient is the IR node for a MemoryAgent decorator instance.
 
@@ -79,7 +79,7 @@ type MemoryAgentClient struct {
 ```
 
 <a name="MemoryAgentClient.AddInstantiation"></a>
-### func \(\*MemoryAgentClient\) [AddInstantiation](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L109>)
+### func \(\*MemoryAgentClient\) [AddInstantiation](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L109>)
 
 ```go
 func (node *MemoryAgentClient) AddInstantiation(builder golang.NamespaceBuilder) error
@@ -88,7 +88,7 @@ func (node *MemoryAgentClient) AddInstantiation(builder golang.NamespaceBuilder)
 Implements golang.Instantiable
 
 <a name="MemoryAgentClient.AddInterfaces"></a>
-### func \(\*MemoryAgentClient\) [AddInterfaces](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L126>)
+### func \(\*MemoryAgentClient\) [AddInterfaces](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L126>)
 
 ```go
 func (node *MemoryAgentClient) AddInterfaces(builder golang.ModuleBuilder) error
@@ -97,7 +97,7 @@ func (node *MemoryAgentClient) AddInterfaces(builder golang.ModuleBuilder) error
 Implements golang.ProvidesInterface
 
 <a name="MemoryAgentClient.AddToWorkspace"></a>
-### func \(\*MemoryAgentClient\) [AddToWorkspace](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L121>)
+### func \(\*MemoryAgentClient\) [AddToWorkspace](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L121>)
 
 ```go
 func (node *MemoryAgentClient) AddToWorkspace(builder golang.WorkspaceBuilder) error
@@ -106,7 +106,7 @@ func (node *MemoryAgentClient) AddToWorkspace(builder golang.WorkspaceBuilder) e
 Implements golang.ProvidesModule
 
 <a name="MemoryAgentClient.GetInterface"></a>
-### func \(\*MemoryAgentClient\) [GetInterface](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L131>)
+### func \(\*MemoryAgentClient\) [GetInterface](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L131>)
 
 ```go
 func (node *MemoryAgentClient) GetInterface(ctx ir.BuildContext) (service.ServiceInterface, error)
@@ -115,7 +115,7 @@ func (node *MemoryAgentClient) GetInterface(ctx ir.BuildContext) (service.Servic
 Implements service.ServiceNode
 
 <a name="MemoryAgentClient.ImplementsGolangNode"></a>
-### func \(\*MemoryAgentClient\) [ImplementsGolangNode](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L136>)
+### func \(\*MemoryAgentClient\) [ImplementsGolangNode](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L136>)
 
 ```go
 func (node *MemoryAgentClient) ImplementsGolangNode()
@@ -124,7 +124,7 @@ func (node *MemoryAgentClient) ImplementsGolangNode()
 Implements golang.Node
 
 <a name="MemoryAgentClient.Name"></a>
-### func \(\*MemoryAgentClient\) [Name](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L99>)
+### func \(\*MemoryAgentClient\) [Name](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L99>)
 
 ```go
 func (node *MemoryAgentClient) Name() string
@@ -133,7 +133,7 @@ func (node *MemoryAgentClient) Name() string
 Implements ir.IRNode
 
 <a name="MemoryAgentClient.String"></a>
-### func \(\*MemoryAgentClient\) [String](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L104>)
+### func \(\*MemoryAgentClient\) [String](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L104>)
 
 ```go
 func (node *MemoryAgentClient) String() string
@@ -142,7 +142,7 @@ func (node *MemoryAgentClient) String() string
 Implements ir.IRNode
 
 <a name="MemoryStoreClient"></a>
-## type [MemoryStoreClient](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L16-L23>)
+## type [MemoryStoreClient](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L16-L23>)
 
 MemoryStoreClient is the IR node for a memory store instance.
 
@@ -158,7 +158,7 @@ type MemoryStoreClient struct {
 ```
 
 <a name="MemoryStoreClient.AddInstantiation"></a>
-### func \(\*MemoryStoreClient\) [AddInstantiation](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L44>)
+### func \(\*MemoryStoreClient\) [AddInstantiation](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L44>)
 
 ```go
 func (node *MemoryStoreClient) AddInstantiation(builder golang.NamespaceBuilder) error
@@ -167,7 +167,7 @@ func (node *MemoryStoreClient) AddInstantiation(builder golang.NamespaceBuilder)
 Implements golang.Instantiable
 
 <a name="MemoryStoreClient.AddInterfaces"></a>
-### func \(\*MemoryStoreClient\) [AddInterfaces](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L61>)
+### func \(\*MemoryStoreClient\) [AddInterfaces](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L61>)
 
 ```go
 func (node *MemoryStoreClient) AddInterfaces(builder golang.ModuleBuilder) error
@@ -176,7 +176,7 @@ func (node *MemoryStoreClient) AddInterfaces(builder golang.ModuleBuilder) error
 Implements golang.ProvidesInterface
 
 <a name="MemoryStoreClient.AddToWorkspace"></a>
-### func \(\*MemoryStoreClient\) [AddToWorkspace](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L56>)
+### func \(\*MemoryStoreClient\) [AddToWorkspace](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L56>)
 
 ```go
 func (node *MemoryStoreClient) AddToWorkspace(builder golang.WorkspaceBuilder) error
@@ -185,7 +185,7 @@ func (node *MemoryStoreClient) AddToWorkspace(builder golang.WorkspaceBuilder) e
 Implements golang.ProvidesModule
 
 <a name="MemoryStoreClient.GetInterface"></a>
-### func \(\*MemoryStoreClient\) [GetInterface](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L66>)
+### func \(\*MemoryStoreClient\) [GetInterface](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L66>)
 
 ```go
 func (node *MemoryStoreClient) GetInterface(ctx ir.BuildContext) (service.ServiceInterface, error)
@@ -194,7 +194,7 @@ func (node *MemoryStoreClient) GetInterface(ctx ir.BuildContext) (service.Servic
 Implements service.ServiceNode
 
 <a name="MemoryStoreClient.ImplementsGolangNode"></a>
-### func \(\*MemoryStoreClient\) [ImplementsGolangNode](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L71>)
+### func \(\*MemoryStoreClient\) [ImplementsGolangNode](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L71>)
 
 ```go
 func (node *MemoryStoreClient) ImplementsGolangNode()
@@ -203,7 +203,7 @@ func (node *MemoryStoreClient) ImplementsGolangNode()
 Implements golang.Node
 
 <a name="MemoryStoreClient.Name"></a>
-### func \(\*MemoryStoreClient\) [Name](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L34>)
+### func \(\*MemoryStoreClient\) [Name](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L34>)
 
 ```go
 func (node *MemoryStoreClient) Name() string
@@ -212,7 +212,7 @@ func (node *MemoryStoreClient) Name() string
 Implements ir.IRNode
 
 <a name="MemoryStoreClient.String"></a>
-### func \(\*MemoryStoreClient\) [String](<https://github.com/Abdomash/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L39>)
+### func \(\*MemoryStoreClient\) [String](<https://github.com/vaastav/dmas_forge/blob/main/ai_plugins/memory_plugin/ir.go#L39>)
 
 ```go
 func (node *MemoryStoreClient) String() string

--- a/ai_runtime/plugins/memory/README.md
+++ b/ai_runtime/plugins/memory/README.md
@@ -48,7 +48,7 @@ The \[core.Memory\] interface defines the memory storage abstraction. The interf
 
 
 <a name="InMemoryStore"></a>
-## type [InMemoryStore](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L12-L15>)
+## type [InMemoryStore](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L12-L15>)
 
 InMemoryStore implements core.Memory using a thread\-safe in\-memory map.
 
@@ -59,7 +59,7 @@ type InMemoryStore struct {
 ```
 
 <a name="NewInMemoryStore"></a>
-### func [NewInMemoryStore](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L18>)
+### func [NewInMemoryStore](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L18>)
 
 ```go
 func NewInMemoryStore(ctx context.Context) (*InMemoryStore, error)
@@ -68,7 +68,7 @@ func NewInMemoryStore(ctx context.Context) (*InMemoryStore, error)
 NewInMemoryStore creates a new in\-memory store.
 
 <a name="InMemoryStore.Delete"></a>
-### func \(\*InMemoryStore\) [Delete](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L41>)
+### func \(\*InMemoryStore\) [Delete](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L41>)
 
 ```go
 func (s *InMemoryStore) Delete(ctx context.Context, key string) error
@@ -77,7 +77,7 @@ func (s *InMemoryStore) Delete(ctx context.Context, key string) error
 
 
 <a name="InMemoryStore.List"></a>
-### func \(\*InMemoryStore\) [List](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L48>)
+### func \(\*InMemoryStore\) [List](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L48>)
 
 ```go
 func (s *InMemoryStore) List(ctx context.Context) ([]string, error)
@@ -86,7 +86,7 @@ func (s *InMemoryStore) List(ctx context.Context) ([]string, error)
 
 
 <a name="InMemoryStore.Recall"></a>
-### func \(\*InMemoryStore\) [Recall](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L31>)
+### func \(\*InMemoryStore\) [Recall](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L31>)
 
 ```go
 func (s *InMemoryStore) Recall(ctx context.Context, key string) (string, error)
@@ -95,7 +95,7 @@ func (s *InMemoryStore) Recall(ctx context.Context, key string) (string, error)
 
 
 <a name="InMemoryStore.Store"></a>
-### func \(\*InMemoryStore\) [Store](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L24>)
+### func \(\*InMemoryStore\) [Store](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/store.go#L24>)
 
 ```go
 func (s *InMemoryStore) Store(ctx context.Context, key string, value string) error
@@ -104,7 +104,7 @@ func (s *InMemoryStore) Store(ctx context.Context, key string, value string) err
 
 
 <a name="MemoryAgent"></a>
-## type [MemoryAgent](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L145-L149>)
+## type [MemoryAgent](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L145-L149>)
 
 MemoryAgent is a decorator that wraps any core.Agent with LLM\-driven memory capabilities. It registers memory tools on the inner agent and composes tool handlers so that memory tool calls are handled internally while all other tool calls are delegated to the user's handler.
 
@@ -117,7 +117,7 @@ type MemoryAgent struct {
 ```
 
 <a name="NewMemoryAgent"></a>
-### func [NewMemoryAgent](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L153>)
+### func [NewMemoryAgent](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L153>)
 
 ```go
 func NewMemoryAgent(ctx context.Context, agent core.Agent, memStore core.Memory) (*MemoryAgent, error)
@@ -126,7 +126,7 @@ func NewMemoryAgent(ctx context.Context, agent core.Agent, memStore core.Memory)
 NewMemoryAgent wraps the given agent with memory capabilities. It registers memory tool definitions and a default handler on the inner agent.
 
 <a name="MemoryAgent.AddSystemPrompt"></a>
-### func \(\*MemoryAgent\) [AddSystemPrompt](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L176>)
+### func \(\*MemoryAgent\) [AddSystemPrompt](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L176>)
 
 ```go
 func (m *MemoryAgent) AddSystemPrompt(ctx context.Context, prompt string) error
@@ -135,7 +135,7 @@ func (m *MemoryAgent) AddSystemPrompt(ctx context.Context, prompt string) error
 AddSystemPrompt appends a memory instruction to the user's prompt and forwards it to the inner agent.
 
 <a name="MemoryAgent.AddTools"></a>
-### func \(\*MemoryAgent\) [AddTools](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L182>)
+### func \(\*MemoryAgent\) [AddTools](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L182>)
 
 ```go
 func (m *MemoryAgent) AddTools(ctx context.Context, tooldefs map[string]openai.ChatCompletionToolParam) error
@@ -144,7 +144,7 @@ func (m *MemoryAgent) AddTools(ctx context.Context, tooldefs map[string]openai.C
 AddTools forwards tool registration to the inner agent. Memory tools were already registered in the constructor.
 
 <a name="MemoryAgent.LLMCall"></a>
-### func \(\*MemoryAgent\) [LLMCall](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L187>)
+### func \(\*MemoryAgent\) [LLMCall](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L187>)
 
 ```go
 func (m *MemoryAgent) LLMCall(ctx context.Context, query string) (string, error)
@@ -153,7 +153,7 @@ func (m *MemoryAgent) LLMCall(ctx context.Context, query string) (string, error)
 LLMCall forwards to the inner agent.
 
 <a name="MemoryAgent.LLMCallWithTools"></a>
-### func \(\*MemoryAgent\) [LLMCallWithTools](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L192>)
+### func \(\*MemoryAgent\) [LLMCallWithTools](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L192>)
 
 ```go
 func (m *MemoryAgent) LLMCallWithTools(ctx context.Context, query string) (string, error)
@@ -162,7 +162,7 @@ func (m *MemoryAgent) LLMCallWithTools(ctx context.Context, query string) (strin
 LLMCallWithTools forwards to the inner agent.
 
 <a name="MemoryAgent.RegisterToolCallHandler"></a>
-### func \(\*MemoryAgent\) [RegisterToolCallHandler](<https://github.com/Abdomash/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L199>)
+### func \(\*MemoryAgent\) [RegisterToolCallHandler](<https://github.com/vaastav/dmas_forge/blob/main/ai_runtime/plugins/memory/agent.go#L199>)
 
 ```go
 func (m *MemoryAgent) RegisterToolCallHandler(ctx context.Context, toolHandlerFn core.ToolHandlerFn) error


### PR DESCRIPTION
The repo links in the gomarkdoc generated docs point to my fork not the original link. 