### PR TITLE
Remove timeouts from generated A2A server

### DIFF
--- a/ai_plugins/a2a/a2acodegen/servergen.go
+++ b/ai_plugins/a2a/a2acodegen/servergen.go
@@ -98,7 +98,7 @@ func (handler *{{.Name}}) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	srv, err := server.NewA2AServer(agentCard, baseTaskManager, server.WithCORSEnabled(true))
+	srv, err := server.NewA2AServer(agentCard, baseTaskManager, server.WithCORSEnabled(true), server.WithReadTimeout(0), server.WithWriteTimeout(0))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Timeouts should be explicitly handled by Blueprint plugins. Disabling default timeouts for underlying communication protocols is the right way to ensure modularity with other Blueprint plugins.

Fixes #10 
