### PR TITLE
fix: duplicate --modfile flag definitions

### DIFF
--- a/examples/marketing-agency/wiring/specs/common.go
+++ b/examples/marketing-agency/wiring/specs/common.go
@@ -1,8 +1,6 @@
 package specs
 
 import (
-	"flag"
-
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/wiring"
 	"github.com/blueprint-uservices/blueprint/plugins/workflow"
 
@@ -18,8 +16,6 @@ type marketingServices struct {
 	logoService        string
 	coordinatorService string
 }
-
-var modelFile = flag.String("modfile", "model.json", "Specific model related information")
 
 func defineMarketingServices(spec wiring.WiringSpec) (marketingServices, error) {
 	model, err := model.GetModelInfo()

--- a/examples/travel-planning/wiring/specs/default.go
+++ b/examples/travel-planning/wiring/specs/default.go
@@ -1,8 +1,6 @@
 package specs
 
 import (
-	"flag"
-
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/wiring"
 	"github.com/blueprint-uservices/blueprint/plugins/cmdbuilder"
 	"github.com/blueprint-uservices/blueprint/plugins/goproc"
@@ -20,8 +18,6 @@ var Docker = cmdbuilder.SpecOption{
 	Description: "Deploys travel-planning agents in containers with HTTP, using OpenAI models",
 	Build:       makeDockerSpec,
 }
-
-var modelFile = flag.String("modfile", "model.json", "Specific model related information")
 
 func makeDockerSpec(spec wiring.WiringSpec) ([]string, error) {
 	modelInfo, err := model.GetModelInfo()


### PR DESCRIPTION
PR #13 refactored the model info reading boilerplate under `ai_plugins/model` but missed a few duplicate definitions, so both `marketing-agency` and `travel-planning` stopped working. Removed these variables in this PR.