### PR TITLE
fix: remove financial analyzer dependency workaround

### DIFF
--- a/examples/financial-analyzer/wiring/specs/common.go
+++ b/examples/financial-analyzer/wiring/specs/common.go
@@ -35,12 +35,11 @@ func defineFinancialServices(spec wiring.WiringSpec) (financialServices, error) 
 	analystCore := openai_plugin.OpenAILLMAgent(spec, "analyst_core", minfo.URL, minfo.Key, minfo.Name, openai_plugin.AgentConfig{})
 	writerCore := openai_plugin.OpenAILLMAgent(spec, "writer_core", minfo.URL, minfo.Key, minfo.Name, openai_plugin.AgentConfig{})
 	coordinatorCore := openai_plugin.OpenAILLMAgent(spec, "coordinator_core", minfo.URL, minfo.Key, minfo.Name, openai_plugin.AgentConfig{})
-	researcherCore := openai_plugin.OpenAILLMAgent(spec, "researcher_core", minfo.URL, minfo.Key, minfo.Name, openai_plugin.AgentConfig{})
 
 	services := financialServices{}
 	services.collectorService = workflow.Service[wf.DataCollectorAgent](spec, "collector_service", collectorCore, mcpServerURLs)
 	services.evaluatorService = workflow.Service[wf.DataEvaluatorAgent](spec, "evaluator_service", evaluatorCore)
-	services.researchService = workflow.Service[wf.ResearchQualityController](spec, "research_quality_service", researcherCore, services.collectorService, services.evaluatorService)
+	services.researchService = workflow.Service[wf.ResearchQualityController](spec, "research_quality_service", services.collectorService, services.evaluatorService)
 	services.analystService = workflow.Service[wf.FinancialAnalystAgent](spec, "analyst_service", analystCore)
 	services.writerService = workflow.Service[wf.ReportWriterAgent](spec, "writer_service", writerCore)
 	services.coordinatorService = workflow.Service[wf.FinancialAnalyzerCoordinator](

--- a/examples/financial-analyzer/workflow/research_quality_controller.go
+++ b/examples/financial-analyzer/workflow/research_quality_controller.go
@@ -4,25 +4,20 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	"github.com/vaastav/dmas_forge/ai_runtime/core"
 )
 
 type ResearchQualityControllerImpl struct {
-	agent     core.Agent
 	collector DataCollectorAgent
 	evaluator DataEvaluatorAgent
 }
 
 func NewResearchQualityControllerImpl(
 	ctx context.Context,
-	agent core.Agent,
 	collector DataCollectorAgent,
 	evaluator DataEvaluatorAgent,
 ) (ResearchQualityController, error) {
 	_ = ctx
 	return &ResearchQualityControllerImpl{
-		agent:     agent,
 		collector: collector,
 		evaluator: evaluator,
 	}, nil


### PR DESCRIPTION
Given the latest commits (`3725bf4`), the workaround in the financial-analyzer for the `ai_runtime` dependency issues is no longer needed, so I am reverting it here. This also closes #19.